### PR TITLE
Remove Google Analytics Tracking

### DIFF
--- a/deepstack-trainer/trainer/templates/index.html
+++ b/deepstack-trainer/trainer/templates/index.html
@@ -9,16 +9,7 @@
 
     <title>Deepstack</title>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-9W0B4Q6Q87"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
 
-  gtag('config', 'G-9W0B4Q6Q87');
-</script>
-    
     
 </head>
 
@@ -207,15 +198,5 @@
     //     Materialize.toast('Ready', 4000)
     // });
 </script>
-<script>
 
-gtag('event','pageview', {
-  'event_category': 'views,
-  'event_label': 'Home Page',
-  'value': <value>
-});
-
-
-
-</script>
 </html>


### PR DESCRIPTION
Since Home Assistant prides itself on local and private i figured users would not like knowing everytime they open the addon its tracked by the original developer.  
   
Proposing we lose the google analytics script on the index.html so this can be truly local.